### PR TITLE
Fix copybook detection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "cobol-lsp.cpy-manager.paths-local": ["DOGGOS/COPY"],
-  "files.associations": { "**/*.CPY": "COBOL Copybook" },
   "terminal.integrated.profiles.windows": {
     "Git Bash": {
       "source": "Git Bash"


### PR DESCRIPTION
By removing an obsolete language ID association for *.cpy files.