### PR TITLE
Disable secure credential store so we can use latest Zowe Explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
   "[cobol]": {
     "editor.formatOnSave": true
   },
-  "files.autoSave": "off"
+  "files.autoSave": "off",
+  "zowe.security.secureCredentialsEnabled": false,
 }


### PR DESCRIPTION
This setting disables the Zowe Explore secure credential store that is not used as part of the workshop anyway.

Thanks to it Zowe Explorer successfully activates and we can use the latest version.