### PR TITLE
add the some opts back

### DIFF
--- a/DOGGOS/COBOL/BUILDZ.js
+++ b/DOGGOS/COBOL/BUILDZ.js
@@ -31,7 +31,12 @@ var cobol_binary = cobol.compileAndBind({
     name: "DOGGOS",
     srcs: "*.CBL",
     syslibs: [`//'${os.user()}.DOGGOS.COPYBOOK'`],
-    opts: intertest.options.cobol,
+    opts: [
+        ...intertest.options.cobol,
+        "APOST",
+        "RENT",
+        "LINECOUNT(60)"
+    ],
     syslibs_binder: [
         "//CEE.SCEELKED",
     ],


### PR DESCRIPTION
This change is based on #65 
Add those opts back, because those are not default in the `intertest` rules for COBOL compiling.
```
        "APOST",
        "RENT",
        "LINECOUNT(60)"
```